### PR TITLE
Add command category

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "commands": [
       {
         "command": "extension.showPreview",
-        "title": "Show preview"
+        "title": "Show preview",
+        "category": "Jupyter",
       }
     ],
     "menus": {


### PR DESCRIPTION
Fix issue #11. Command now shows as **Jupyter: Show preview**